### PR TITLE
Do not limit NBT when reading from buffer

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/nbt/NBTLimiter.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/nbt/NBTLimiter.java
@@ -39,7 +39,7 @@ public interface NBTLimiter {
     }
 
     static NBTLimiter forBuffer(final @NotNull Object byteBuf) {
-        return forBuffer(byteBuf, DEFAULT_MAX_SIZE);
+        return forBuffer(byteBuf, Integer.MAX_VALUE);
     }
 
     static NBTLimiter forBuffer(final @NotNull Object byteBuf, final int max) {


### PR DESCRIPTION
The current limit is too low and throws for legitimate packets.