### PR TITLE
Fix dimension type copying not using new data entry

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/dimension/StaticDimensionType.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/dimension/StaticDimensionType.java
@@ -198,7 +198,7 @@ public class StaticDimensionType extends AbstractMappedEntity implements Dimensi
     @Override
     public DimensionType copy(@Nullable TypesBuilderData newData) {
         return new StaticDimensionType(
-                this.data, this.hasFixedTime, this.skybox, this.cardinalLight, this.attributes, this.timelinesRef,
+                newData, this.hasFixedTime, this.skybox, this.cardinalLight, this.attributes, this.timelinesRef,
                 this.fixedTime, this.natural, this.bedWorks, this.respawnAnchorWorks, this.effects, this.coordinateScale,
                 this.minY, this.height, this.monsterSpawnLightLevel, this.monsterSpawnBlockLightLimit, this.hasSkylight,
                 this.hasCeiling, this.logicalHeight, this.infiniburn, this.ambientLight

--- a/api/src/main/java/com/github/retrooper/packetevents/util/mappings/SynchronizedRegistriesHandler.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/mappings/SynchronizedRegistriesHandler.java
@@ -203,7 +203,11 @@ public final class SynchronizedRegistriesHandler {
     @FunctionalInterface
     public interface NbtEntryDecoder<T> {
 
-        T decode(NBT nbt, PacketWrapper<?> version, @Nullable TypesBuilderData data);
+        static <T extends MappedEntity & CopyableEntity<T>> NbtEntryDecoder<T> fromDecoder(NbtDecoder<T> decoder) {
+            return (tag, wrapper, data) -> decoder.decode(tag, wrapper).copy(data);
+        }
+
+        T decode(NBT tag, PacketWrapper<?> wrapper, @Nullable TypesBuilderData data);
     }
 
     @ApiStatus.Internal
@@ -229,8 +233,7 @@ public final class SynchronizedRegistriesHandler {
                 IRegistry<T> baseRegistry,
                 NbtDecoder<T> decoder
         ) {
-            this(baseRegistry, (NbtEntryDecoder<T>) (tag, wrapper, data) ->
-                    decoder.decode(tag, wrapper).copy(data));
+            this(baseRegistry, NbtEntryDecoder.fromDecoder(decoder));
         }
 
         public RegistryEntry(


### PR DESCRIPTION
Should fix https://github.com/retrooper/packetevents/issues/1437

(cherry picked from commit 2390e06ad32a94a2e44e2ded867ccbe3fba33b8c)