### PR TITLE
fix: re-verify encoder position after compression-enable relocate

### DIFF
--- a/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsDecoder.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsDecoder.java
@@ -142,8 +142,21 @@ public class PacketEventsDecoder extends MessageToMessageDecoder<ByteBuf> {
         if (!preViaVersion) {
             // 1.20.4 has a bug where userEventTriggered is called twice, so Via relocates twice uselessly and we must do so
             ServerConnectionInitializer.relocateHandlers(ctx.channel(), user, false, true);
-            if (PacketEvents.getAPI().getSettings().isPreViaInjection() && ViaVersionUtil.isAvailable())
+            // reset the encoder's compression latch so the next outbound write
+            // re-verifies its position relative to compress: relocateHandlers'
+            // isAlreadyBefore only compares against "encoder" and silently
+            // bails when compress lands between PE and vanilla, the lazy check
+            // in PacketEventsEncoder.write catches that case
+            //
+            // relies on relocateHandlers bailing before setting hasBeenRelocated;
+            // if that order ever changes this fallback goes silent
+            PacketEventsEncoder enc = (PacketEventsEncoder) ctx.channel().pipeline().get(PacketEvents.ENCODER_NAME);
+            if (enc != null) enc.markCompressionUnverified();
+            if (PacketEvents.getAPI().getSettings().isPreViaInjection() && ViaVersionUtil.isAvailable()) {
                 ServerConnectionInitializer.relocateHandlers(ctx.channel(), user, true, true);
+                PacketEventsEncoder preEnc = (PacketEventsEncoder) ctx.channel().pipeline().get("pre-" + PacketEvents.ENCODER_NAME);
+                if (preEnc != null) preEnc.markCompressionUnverified();
+            }
         }
         super.userEventTriggered(ctx, event);
     }

--- a/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsEncoder.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsEncoder.java
@@ -244,6 +244,13 @@ public class PacketEventsEncoder extends ChannelOutboundHandlerAdapter {
         }
     }
 
+    // called by the decoder after a pipeline relocation, so the next outbound
+    // write runs the lazy pipeline-layout check in handleCompression() again
+    // instead of trusting the preset latch
+    void markCompressionUnverified() {
+        this.handledCompression = false;
+    }
+
     private boolean handleCompression(ChannelHandlerContext ctx, ByteBuf buffer) throws InvocationTargetException {
         if (handledCompression) return false;
         int compressIndex = ctx.pipeline().names().indexOf("compress");


### PR DESCRIPTION
@Axionize you've said you [patched this in 3.0 but haven't had the time to port it to here](https://github.com/GrimAnticheat/Grim/pull/2584#issuecomment-4235118596), but this is actively blocking me so I wanted to PR it. I did ping you on Discord to ask for direction but didn't receive any response, so let me know if this useful or if this fix is inappropriate.

From my understanding, after `PacketEventsDecoder.userEventTriggered` runs `relocateHandlers` on Paper's compression-enable event, the encoder's `handledCompression` latch is reset so the next outbound write re-runs the lazy pipeline-layout check in `handleCompression()`.

### Root cause

`relocateHandlers` → `isAlreadyBefore(encoder, target)` only compares against `"encoder"` / `"via-encoder"` and is unaware of `compress`. When `compress` lands between PE and vanilla, the check returns true, the relocate bails early, and PE sits downstream of `compress`, reading compressed bytes as the packet ID.

The lazy check in `handleCompression()` already compares `compressIndex` to `peEncoderIdx` directly but was unreachable with `handledCompression` latched at construction.

Safe because `isAlreadyBefore` bails before `hasBeenRelocated = true` is set, so the lazy path's `force=false` relocate can proceed on the buggy path. On the healthy path, PE is correctly positioned and the lazy check's position check bails before calling `relocateHandlers`.

### Reproduction

GrimAnticheat/Grim#2552. Same error shape in [#2592](GrimAnticheat/Grim#2592), [#2569](GrimAnticheat/Grim#2569), [#2485](GrimAnticheat/Grim#2485), [#2421](GrimAnticheat/Grim#2421).

### Tested

| Server | Client | Via | Result |
|---|---|---|---|
| Paper 1.21.11 | 26.1.2 | yes | passes |
| Paper 1.20.2 | 26.1.2 | yes | passes (was failing) |
| Paper 1.20.2 | 1.20.2 | no | passes |