### PR TITLE
Decouple pre-Via and post-Via encoder/decoder state

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/event/ProtocolPacketEvent.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/ProtocolPacketEvent.java
@@ -72,7 +72,8 @@ public abstract class ProtocolPacketEvent extends PacketEvent implements PlayerE
         this.user = user;
         this.player = player;
 
-        if(autoProtocolTranslation || user.getClientVersion() == null) {
+        boolean serverProtocolView = autoProtocolTranslation || user.getClientVersion() == null;
+        if (serverProtocolView) {
             this.serverVersion = PacketEvents.getAPI().getServerManager().getVersion();
         } else {
             this.serverVersion = user.getClientVersion().toServerVersion();
@@ -90,14 +91,18 @@ public abstract class ProtocolPacketEvent extends PacketEvent implements PlayerE
         }
 
         ClientVersion version = serverVersion.toClientVersion();
-        this.connectionState = packetSide == PacketSide.CLIENT ? user.getDecoderState() : user.getEncoderState();
+        if (packetSide == PacketSide.CLIENT) {
+            this.connectionState = serverProtocolView ? user.getPostViaDecoderState() : user.getPreViaDecoderState();
+        } else {
+            this.connectionState = serverProtocolView ? user.getPostViaEncoderState() : user.getPreViaEncoderState();
+        }
         PacketTypeCommon packetType = PacketType.getById(packetSide, this.connectionState, version, this.packetID);
         if (packetType == null) {
             // mojang messed up and keeps sending disconnect packets in the wrong protocol state
             if (PacketType.getById(packetSide, ConnectionState.PLAY, version, packetID) == PacketType.Play.Server.DISCONNECT) {
                 throw new InvalidDisconnectPacketSend();
             }
-            throw new PacketProcessException("Failed to map the Packet ID " + packetID + " to a PacketType constant. Bound: " + packetSide.getOpposite() + ", Connection state: " + user.getDecoderState() + ", Server version: " + serverVersion.getReleaseName());
+            throw new PacketProcessException("Failed to map the Packet ID " + packetID + " to a PacketType constant. Bound: " + packetSide.getOpposite() + ", Connection state: " + this.connectionState + ", Server version: " + serverVersion.getReleaseName());
         }
         this.packetType = packetType;
     }

--- a/api/src/main/java/com/github/retrooper/packetevents/manager/InternalPacketListener.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/manager/InternalPacketListener.java
@@ -43,51 +43,93 @@ import org.jetbrains.annotations.ApiStatus;
 @ApiStatus.Internal
 public class InternalPacketListener extends PacketListenerAbstract {
 
+    private final boolean preVia;
+
     public InternalPacketListener() {
-        this(PacketListenerPriority.LOWEST);
+        this(PacketListenerPriority.LOWEST, false);
     }
 
     public InternalPacketListener(PacketListenerPriority priority) {
+        this(priority, false);
+    }
+
+    public InternalPacketListener(PacketListenerPriority priority, boolean preVia) {
         super(priority);
+        this.preVia = preVia;
+    }
+
+    @Override
+    public boolean isPreVia() {
+        return preVia;
     }
 
     @Override
     public void onPacketSend(PacketSendEvent event) {
         User user = event.getUser();
         if (event.getPacketType() == PacketType.Login.Server.LOGIN_SUCCESS) {
-            Object channel = event.getChannel();
-            //Process outgoing login success packet
-            WrapperLoginServerLoginSuccess loginSuccess = new WrapperLoginServerLoginSuccess(event);
-            UserProfile profile = loginSuccess.getUserProfile();
+            // The post-Via listener owns shared state that must only be updated once per channel:
+            // user-profile mirroring, channel→UUID mapping, and (for the legacy non-config-aware
+            // path) the encoder transition. Skip these on the pre-Via pass to avoid double-writes.
+            if (!preVia) {
+                Object channel = event.getChannel();
+                //Process outgoing login success packet
+                WrapperLoginServerLoginSuccess loginSuccess = new WrapperLoginServerLoginSuccess(event);
+                UserProfile profile = loginSuccess.getUserProfile();
 
-            //Update user profile
-            user.getProfile().setUUID(profile.getUUID());
-            user.getProfile().setName(profile.getName());
-            //Texture properties are passed in login success on 1.19
-            user.getProfile().setTextureProperties(profile.getTextureProperties());
+                //Update user profile
+                user.getProfile().setUUID(profile.getUUID());
+                user.getProfile().setName(profile.getName());
+                //Texture properties are passed in login success on 1.19
+                user.getProfile().setTextureProperties(profile.getTextureProperties());
 
-            //Map username with channel
-            synchronized (channel) {
-                PacketEvents.getAPI().getProtocolManager().setChannel(profile.getUUID(), channel);
+                //Map username with channel
+                synchronized (channel) {
+                    PacketEvents.getAPI().getProtocolManager().setChannel(profile.getUUID(), channel);
+                }
+
+                if (PacketEvents.getAPI().getLogManager().isDebug()) {
+                    PacketEvents.getAPI().getLogManager().debug("Mapped player UUID with their channel " + profile.getUUID() + " " + channel);
+                }
             }
 
-            if (PacketEvents.getAPI().getLogManager().isDebug()) {
-                PacketEvents.getAPI().getLogManager().debug("Mapped player UUID with their channel " + profile.getUUID() + " " + channel);
-            }
-
-            // Switch the user's connection state to new state, but the variable event.getConnectionState() remains LOGIN
-            // We switch user state immediately to remain in sync with vanilla, allowing you to encode packets immediately
+            // Switch the user's connection state immediately so subsequent packets encode in the right
+            // protocol state. Pre-Via and post-Via may transition into different states when ViaVersion
+            // bridges a client whose protocol doesn't have the configuration phase to a server whose
+            // protocol does (or vice-versa), so handle the four cases independently.
             boolean proxy = PacketEvents.getAPI().getInjector().isProxy();
-            if (proxy ? event.getUser().getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_20_2)
-                    : event.getServerVersion().isNewerThanOrEquals(ServerVersion.V_1_20_2)) {
+            ClientVersion peerVersion = event.getUser().getClientVersion();
+            boolean clientHasConfiguration = peerVersion != null && peerVersion.isNewerThanOrEquals(ClientVersion.V_1_20_2);
+            boolean serverHasConfiguration = proxy
+                    ? clientHasConfiguration
+                    : event.getServerVersion().isNewerThanOrEquals(ServerVersion.V_1_20_2);
+
+            if (clientHasConfiguration && serverHasConfiguration) {
                 user.setEncoderState(ConnectionState.CONFIGURATION);
+            } else if (clientHasConfiguration) {
+                user.setPreViaEncoderState(ConnectionState.CONFIGURATION);
+                user.setPostViaEncoderState(ConnectionState.PLAY);
+            } else if (serverHasConfiguration) {
+                user.setPreViaEncoderState(ConnectionState.PLAY);
+                user.setPostViaEncoderState(ConnectionState.CONFIGURATION);
             } else {
                 user.setConnectionState(ConnectionState.PLAY);
             }
         }
 
+        // The remaining handlers operate on the post-Via stream only — they read packet bodies in
+        // the server's protocol and update post-Via state. The pre-Via listener handles its own
+        // configuration transitions below.
+        if (preVia) {
+            if (event.getPacketType() == PacketType.Play.Server.CONFIGURATION_START) {
+                user.setPreViaEncoderState(ConnectionState.CONFIGURATION);
+            } else if (event.getPacketType() == PacketType.Configuration.Server.CONFIGURATION_END) {
+                user.setPreViaEncoderState(ConnectionState.PLAY);
+            }
+            return;
+        }
+
         // The server sends dimension information in configuration phase, since 1.20.2
-        else if (event.getPacketType() == PacketType.Configuration.Server.REGISTRY_DATA) {
+        if (event.getPacketType() == PacketType.Configuration.Server.REGISTRY_DATA) {
             WrapperConfigServerRegistryData packet = new WrapperConfigServerRegistryData(event);
 
             if (packet.getElements() != null) { // 1.20.2 to 1.20.5
@@ -118,9 +160,9 @@ public class InternalPacketListener extends PacketListenerAbstract {
             WrapperPlayServerRespawn packet = new WrapperPlayServerRespawn(event);
             user.setDimensionType(packet.getDimensionType());
         } else if (event.getPacketType() == PacketType.Play.Server.CONFIGURATION_START) {
-            user.setEncoderState(ConnectionState.CONFIGURATION);
+            user.setPostViaEncoderState(ConnectionState.CONFIGURATION);
         } else if (event.getPacketType() == PacketType.Configuration.Server.CONFIGURATION_END) {
-            user.setEncoderState(ConnectionState.PLAY);
+            user.setPostViaEncoderState(ConnectionState.PLAY);
             user.finalizeRegistries(new WrapperConfigServerConfigurationEnd(event));
         }
     }
@@ -129,6 +171,9 @@ public class InternalPacketListener extends PacketListenerAbstract {
     public void onPacketReceive(PacketReceiveEvent event) {
         User user = event.getUser();
         if (event.getPacketType() == PacketType.Handshaking.Client.HANDSHAKE) {
+            // Handshake arrives once per channel before any Via translation could exist; the post-Via
+            // listener is responsible for parsing the wrapper and seeding both directions.
+            if (preVia) return;
             WrapperHandshakingClientHandshake packet = new WrapperHandshakingClientHandshake(event);
             ClientVersion clientVersion = packet.getClientVersion();
             ConnectionState state = packet.getNextConnectionState();
@@ -142,11 +187,23 @@ public class InternalPacketListener extends PacketListenerAbstract {
             user.setClientVersion(clientVersion);
             user.setConnectionState(state);
         } else if (event.getPacketType() == PacketType.Login.Client.LOGIN_SUCCESS_ACK) {
-            user.setDecoderState(ConnectionState.CONFIGURATION);
+            if (preVia) {
+                user.setPreViaDecoderState(ConnectionState.CONFIGURATION);
+            } else {
+                user.setPostViaDecoderState(ConnectionState.CONFIGURATION);
+            }
         } else if (event.getPacketType() == PacketType.Play.Client.CONFIGURATION_ACK) {
-            user.setDecoderState(ConnectionState.CONFIGURATION);
+            if (preVia) {
+                user.setPreViaDecoderState(ConnectionState.CONFIGURATION);
+            } else {
+                user.setPostViaDecoderState(ConnectionState.CONFIGURATION);
+            }
         } else if (event.getPacketType() == PacketType.Configuration.Client.CONFIGURATION_END_ACK) {
-            user.setDecoderState(ConnectionState.PLAY);
+            if (preVia) {
+                user.setPreViaDecoderState(ConnectionState.PLAY);
+            } else {
+                user.setPostViaDecoderState(ConnectionState.PLAY);
+            }
         }
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/player/User.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/player/User.java
@@ -61,8 +61,14 @@ import java.util.concurrent.ConcurrentHashMap;
 public class User implements IRegistryHolder {
 
     private final Object channel;
+    // The post-Via states (server's protocol view).
     private ConnectionState decoderState;
     private ConnectionState encoderState;
+    // The pre-Via states (client's protocol view). When ViaVersion is bridging a client whose
+    // protocol entered CONFIGURATION at a different point than the server, these diverge from
+    // the post-Via fields above and decide which PacketType table to look up against.
+    private ConnectionState preViaDecoderState;
+    private ConnectionState preViaEncoderState;
     private ClientVersion clientVersion;
     private final UserProfile profile;
     private int entityId = -1;
@@ -76,6 +82,8 @@ public class User implements IRegistryHolder {
         this.channel = channel;
         this.decoderState = connectionState;
         this.encoderState = connectionState;
+        this.preViaDecoderState = connectionState;
+        this.preViaEncoderState = connectionState;
         this.clientVersion = clientVersion;
         this.profile = profile;
     }
@@ -137,26 +145,84 @@ public class User implements IRegistryHolder {
         this.setEncoderState(connectionState);
     }
 
+    /**
+     * Returns the post-Via decoder state (server's protocol view).
+     * <p>
+     * For most users — including any code path with no ViaVersion translation — pre-Via and
+     * post-Via decoder states are identical. They diverge only when a client whose protocol
+     * doesn't have the configuration phase is bridged to a server whose protocol does (or
+     * vice-versa); in that case use {@link #getPreViaDecoderState()} for the client-protocol view.
+     */
     public ConnectionState getDecoderState() {
         return this.decoderState;
     }
 
     @ApiStatus.Internal
     public void setDecoderState(ConnectionState decoderState) {
-        this.decoderState = decoderState;
-        PacketEvents.getAPI().getLogManager().debug(
-                "Transitioned " + this.getName() + "'s decoder into " + decoderState + " state!");
+        this.setPreViaDecoderState(decoderState);
+        this.setPostViaDecoderState(decoderState);
     }
 
+    /**
+     * Returns the post-Via encoder state (server's protocol view).
+     * <p>
+     * For most users — including any code path with no ViaVersion translation — pre-Via and
+     * post-Via encoder states are identical. They diverge only when a client whose protocol
+     * doesn't have the configuration phase is bridged to a server whose protocol does (or
+     * vice-versa); in that case use {@link #getPreViaEncoderState()} for the client-protocol view.
+     */
     public ConnectionState getEncoderState() {
         return this.encoderState;
     }
 
     @ApiStatus.Internal
     public void setEncoderState(ConnectionState encoderState) {
-        this.encoderState = encoderState;
+        this.setPreViaEncoderState(encoderState);
+        this.setPostViaEncoderState(encoderState);
+    }
+
+    public ConnectionState getPostViaDecoderState() {
+        return this.decoderState;
+    }
+
+    public ConnectionState getPostViaEncoderState() {
+        return this.encoderState;
+    }
+
+    public ConnectionState getPreViaDecoderState() {
+        return this.preViaDecoderState;
+    }
+
+    public ConnectionState getPreViaEncoderState() {
+        return this.preViaEncoderState;
+    }
+
+    @ApiStatus.Internal
+    public void setPostViaDecoderState(ConnectionState connectionState) {
+        this.decoderState = connectionState;
         PacketEvents.getAPI().getLogManager().debug(
-                "Transitioned " + this.getName() + "'s encoder into " + encoderState + " state!");
+                "Transitioned " + this.getName() + "'s post-Via decoder into " + connectionState + " state!");
+    }
+
+    @ApiStatus.Internal
+    public void setPostViaEncoderState(ConnectionState connectionState) {
+        this.encoderState = connectionState;
+        PacketEvents.getAPI().getLogManager().debug(
+                "Transitioned " + this.getName() + "'s post-Via encoder into " + connectionState + " state!");
+    }
+
+    @ApiStatus.Internal
+    public void setPreViaDecoderState(ConnectionState connectionState) {
+        this.preViaDecoderState = connectionState;
+        PacketEvents.getAPI().getLogManager().debug(
+                "Transitioned " + this.getName() + "'s pre-Via decoder into " + connectionState + " state!");
+    }
+
+    @ApiStatus.Internal
+    public void setPreViaEncoderState(ConnectionState connectionState) {
+        this.preViaEncoderState = connectionState;
+        PacketEvents.getAPI().getLogManager().debug(
+                "Transitioned " + this.getName() + "'s pre-Via encoder into " + connectionState + " state!");
     }
 
     public ClientVersion getClientVersion() {

--- a/api/src/main/java/com/github/retrooper/packetevents/util/EventCreationUtil.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/EventCreationUtil.java
@@ -22,12 +22,14 @@ import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.event.simple.*;
 import com.github.retrooper.packetevents.exception.PacketProcessException;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
 import com.github.retrooper.packetevents.protocol.player.User;
 
 public class EventCreationUtil {
     public static PacketReceiveEvent createReceiveEvent(Object channel, User user, Object player, Object buffer,
                                                         boolean autoProtocolTranslation) throws PacketProcessException {
-        switch (user.getDecoderState()) {
+        ConnectionState state = autoProtocolTranslation ? user.getPostViaDecoderState() : user.getPreViaDecoderState();
+        switch (state) {
             case HANDSHAKING:
                 return new PacketHandshakeReceiveEvent(channel, user, player, buffer, autoProtocolTranslation);
             case STATUS:
@@ -39,12 +41,13 @@ public class EventCreationUtil {
             case CONFIGURATION:
                 return new PacketConfigReceiveEvent(channel, user, player, buffer, autoProtocolTranslation);
         }
-        throw new RuntimeException("Unknown connection state " + user.getDecoderState() + "!");
+        throw new RuntimeException("Unknown connection state " + state + "!");
     }
 
     public static PacketSendEvent createSendEvent(Object channel, User user, Object player, Object buffer,
                                                   boolean autoProtocolTranslation) throws PacketProcessException{
-        switch (user.getEncoderState()) {
+        ConnectionState state = autoProtocolTranslation ? user.getPostViaEncoderState() : user.getPreViaEncoderState();
+        switch (state) {
             case HANDSHAKING:
                 return new PacketHandshakeSendEvent(channel, user, player, buffer, autoProtocolTranslation);
             case STATUS:
@@ -56,6 +59,6 @@ public class EventCreationUtil {
             case CONFIGURATION:
                 return new PacketConfigSendEvent(channel, user, player, buffer, autoProtocolTranslation);
         }
-        throw new RuntimeException("Unknown connection state " + user.getEncoderState() + "!");
+        throw new RuntimeException("Unknown connection state " + state + "!");
     }
 }

--- a/spigot/src/main/java/io/github/retrooper/packetevents/factory/spigot/SpigotPacketEventsBuilder.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/factory/spigot/SpigotPacketEventsBuilder.java
@@ -135,6 +135,11 @@ public class SpigotPacketEventsBuilder {
                     //Register internal packet listener (should be the first listener)
                     //This listener doesn't do any modifications to the packets, just reads data
                     getEventManager().registerListener(new InternalBukkitPacketListener());
+                    // The pre-Via instance maintains its own per-direction state on the pre-Via
+                    // pipeline so a Via-bridged client and the underlying server can observe
+                    // independent configuration-phase transitions without aliasing each other.
+                    getEventManager().registerListener(new InternalBukkitPacketListener(
+                            com.github.retrooper.packetevents.event.PacketListenerPriority.LOWEST, true));
                 }
             }
 

--- a/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsDecoder.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsDecoder.java
@@ -95,10 +95,12 @@ public class PacketEventsDecoder extends MessageToMessageDecoder<ByteBuf> {
         }
 
         boolean debug = PacketEvents.getAPI().getSettings().isDebugEnabled() || SpigotReflectionUtil.isMinecraftServerInstanceDebugging();
+        ConnectionState decoderState = user == null ? null
+                : (preViaVersion ? user.getPreViaDecoderState() : user.getPostViaDecoderState());
         // We log exceptions only if the server is in debug mode or the player is fully connected to the server.
-        if (debug || (user != null && user.getDecoderState() != ConnectionState.HANDSHAKING)) {
+        if (debug || (user != null && decoderState != ConnectionState.HANDSHAKING)) {
             if (PacketEvents.getAPI().getSettings().isFullStackTraceEnabled()) {
-                String state = user != null ? user.getDecoderState().name() : "null";
+                String state = decoderState != null ? decoderState.name() : "null";
                 String clientVersion = user != null ? user.getClientVersion().getReleaseName() : "null";
                 String username = user != null && user.getProfile().getName() != null ? user.getProfile().getName() : player != null ? player.getName() : "null";
 

--- a/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsEncoder.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsEncoder.java
@@ -178,8 +178,10 @@ public class PacketEventsEncoder extends ChannelOutboundHandlerAdapter {
         }
 
         boolean didWeCauseThis = ExceptionUtil.isException(cause, PacketProcessException.class);
+        ConnectionState encoderState = user == null ? null
+                : (preVia ? user.getPreViaEncoderState() : user.getPostViaEncoderState());
         if (didWeCauseThis
-                && (user == null || user.getEncoderState() != ConnectionState.HANDSHAKING)) {
+                && (user == null || encoderState != ConnectionState.HANDSHAKING)) {
             if (!SpigotReflectionUtil.isMinecraftServerInstanceDebugging()) {
                 if (PacketEvents.getAPI().getSettings().isFullStackTraceEnabled()) {
                     cause.printStackTrace();

--- a/spigot/src/main/java/io/github/retrooper/packetevents/manager/InternalBukkitPacketListener.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/manager/InternalBukkitPacketListener.java
@@ -25,11 +25,22 @@ import java.util.UUID;
 @ApiStatus.Internal
 public class InternalBukkitPacketListener extends com.github.retrooper.packetevents.manager.InternalPacketListener {
 
+    public InternalBukkitPacketListener() {
+        super();
+    }
+
+    public InternalBukkitPacketListener(com.github.retrooper.packetevents.event.PacketListenerPriority priority, boolean preVia) {
+        super(priority, preVia);
+    }
+
     @Override
     public void onPacketSend(PacketSendEvent event) {
         super.onPacketSend(event);
 
-        // process after generic internal listener has processed this packet
+        // process after generic internal listener has processed this packet — but only on the
+        // post-Via pass; otherwise we'd resolve the player twice per join.
+        if (isPreVia()) return;
+
         if (event.getPacketType() == PacketType.Login.Server.LOGIN_SUCCESS) {
             WrapperLoginServerLoginSuccess packet = new WrapperLoginServerLoginSuccess(event);
             this.tryUpdatePlayerReference(event, event.getUser(), packet.getUserProfile().getUUID());
@@ -60,24 +71,24 @@ public class InternalBukkitPacketListener extends com.github.retrooper.packeteve
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
         if (event.getPacketType() == PacketType.Handshaking.Client.HANDSHAKE) {
+            // Only the post-Via listener owns handshake processing; pre-Via fires after Via has
+            // already chosen the translated protocol version and would clobber that choice.
+            if (isPreVia()) return;
+
             User user = event.getUser();
             WrapperHandshakingClientHandshake packet = new WrapperHandshakingClientHandshake(event);
             ClientVersion clientVersion = packet.getClientVersion();
             ConnectionState state = packet.getNextConnectionState();
 
             String feature;
-            if (!isPreVia()) {
-                if (ViaVersionUtil.isAvailable()) {
-                    clientVersion = ClientVersion.getById(ViaVersionUtil.getProtocolVersion(user));
-                    feature = "ViaVersion";
-                } else if (ProtocolSupportUtil.isAvailable()) {
-                    clientVersion = ClientVersion.getById(ProtocolSupportUtil.getProtocolVersion(user.getAddress()));
-                    feature = "ProtocolSupport";
-                } else {
-                    feature = null;
-                }
+            if (ViaVersionUtil.isAvailable()) {
+                clientVersion = ClientVersion.getById(ViaVersionUtil.getProtocolVersion(user));
+                feature = "ViaVersion";
+            } else if (ProtocolSupportUtil.isAvailable()) {
+                clientVersion = ClientVersion.getById(ProtocolSupportUtil.getProtocolVersion(user.getAddress()));
+                feature = "ProtocolSupport";
             } else {
-                feature = "Client Version Handshake";
+                feature = null;
             }
 
             LogManager logger = PacketEvents.getAPI().getLogManager();


### PR DESCRIPTION
## Summary

When ViaVersion bridges a client whose protocol doesn't have the configuration phase (≤1.20.1) to a server whose protocol does (≥1.20.2), or vice-versa, the pre-Via and post-Via halves of the netty pipeline see different LOGIN→PLAY/CONFIGURATION transition timing. A single shared `encoderState`/`decoderState` on `User` aliases the two and produces stale `PacketType` lookups — surfacing as `Failed to map the Packet ID … to a PacketType constant. Bound: CLIENT, Connection state: LOGIN`.

This splits the state into per-direction × per-Via fields, choosing the right one based on `autoProtocolTranslation`. The bukkit listener now registers a second pre-Via instance that drives state transitions on the pre-Via half independently.

Fixes GrimAnticheat/Grim#2552.

## Changes

- `User.java` — adds `preViaEncoderState` / `preViaDecoderState` alongside the existing fields (which become the post-Via view). Legacy `setEncoderState` / `setDecoderState` set both halves so non-Via callers behave the same.
- `EventCreationUtil.java` + `ProtocolPacketEvent.java` — pick post-Via state when `autoProtocolTranslation`, pre-Via otherwise.
- `InternalPacketListener.java` — `LOGIN_SUCCESS` handles all four `(client has CONFIG, server has CONFIG)` combinations, setting pre-Via and post-Via independently. Adds a `preVia` constructor flag so the same class drives both halves.
- `InternalBukkitPacketListener.java` + `SpigotPacketEventsBuilder.java` — second listener instance with `isPreVia()=true` registered for pre-Via transitions; player-reference / handshake-version paths stay on the post-Via instance only so they don't double-fire.
- Spigot encoder/decoder `exceptionCaught` reads the matching pre-Via or post-Via state for the HANDSHAKING gate.

## Test plan

Built and shaded into Grim 2.x, deployed to test-server, ran every combination. No `PacketProcessException` on any server log; player joins and `/grim version` succeed.

- [x] post-client × post-server, no Via — `paper-1.21.11` + `1.21.11-vanilla`
- [x] post-client × post-server, with Via — `paper-1.21.11` + Via + `1.21.11-vanilla`
- [x] pre-client × post-server (asymmetric, ViaBackwards) — `paper-1.21.11` + `1.19.4-vanilla`
- [x] post-client × pre-server (asymmetric, ViaVersion) — `paper-1.16.5` + `1.21.11-vanilla` and `1.20.6-vanilla`
- [x] pre-client × pre-server (Via on server) — `paper-1.16.5` + `1.19.4-vanilla`
