### PR TITLE
sponge: invoke pre-via packet listeners

### DIFF
--- a/sponge/src/main/java/io/github/retrooper/packetevents/sponge/injector/connection/ServerConnectionInitializer.java
+++ b/sponge/src/main/java/io/github/retrooper/packetevents/sponge/injector/connection/ServerConnectionInitializer.java
@@ -28,10 +28,12 @@ import com.github.retrooper.packetevents.util.FakeChannelUtil;
 import com.github.retrooper.packetevents.util.PacketEventsImplHelper;
 import io.github.retrooper.packetevents.sponge.injector.handlers.PacketEventsDecoder;
 import io.github.retrooper.packetevents.sponge.injector.handlers.PacketEventsEncoder;
+import io.github.retrooper.packetevents.sponge.util.viaversion.ViaVersionUtil;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 
 
@@ -70,7 +72,9 @@ public class ServerConnectionInitializer {
                 return;
             }
 
-            relocateHandlers(channel, null, user);
+            relocateHandlers(channel, user, false, false);
+            if (PacketEvents.getAPI().getSettings().isPreViaInjection() && ViaVersionUtil.isAvailable())
+                relocateHandlers(channel, user, true, false);
 
             channel.closeFuture().addListener((ChannelFutureListener) future -> PacketEventsImplHelper.handleDisconnection(user.getChannel(), user.getUUID()));
             PacketEvents.getAPI().getProtocolManager().setUser(channel, user);
@@ -92,33 +96,91 @@ public class ServerConnectionInitializer {
         }
     }
 
-    public static void relocateHandlers(Channel ctx, PacketEventsDecoder decoder, User user) {
-        // Decoder == null means we haven't made handlers for the user yet
+    public static void relocateHandlers(Channel ctx, User user, boolean preVia, boolean force) {
         try {
-            ChannelHandler encoder;
-            if (decoder != null) {
-                // This patches a bug where PE 2.0 handlers keep jumping behind one another causing a stackoverflow
-                if (decoder.hasBeenRelocated) return;
-                // Make sure we only relocate because of compression once
-                decoder.hasBeenRelocated = true;
-                decoder = (PacketEventsDecoder) ctx.pipeline().remove(PacketEvents.DECODER_NAME);
-                encoder = ctx.pipeline().remove(PacketEvents.ENCODER_NAME);
-                decoder = new PacketEventsDecoder(decoder);
-                encoder = new PacketEventsEncoder(encoder);
+            if (PacketEvents.getAPI().getSettings().isDebugEnabled())
+                PacketEvents.getAPI().getLogManager().debug("Pre relocate, preVia: " + preVia + ", " + ChannelHelper.pipelineHandlerNamesAsString(ctx));
+
+            String encoderName = preVia ? "pre-" + PacketEvents.ENCODER_NAME : PacketEvents.ENCODER_NAME;
+            String decoderName = preVia ? "pre-" + PacketEvents.DECODER_NAME : PacketEvents.DECODER_NAME;
+
+            // Determine where we WANT to be.
+            String targetDecoderName;
+            String targetEncoderName;
+
+            if (preVia) {
+                targetEncoderName = "via-encoder";
+                targetDecoderName = "via-decoder";
             } else {
-                encoder = new PacketEventsEncoder(user);
-                decoder = new PacketEventsDecoder(user);
+                targetDecoderName = ctx.pipeline().names().contains("inbound_config") ? "inbound_config" : "decoder";
+                targetEncoderName = ctx.pipeline().names().contains("outbound_config") ? "outbound_config" : "encoder";
             }
-            // We are targeting the encoder and decoder since we don't want to target specific plugins
-            // (ProtocolSupport has changed its handler name in the past)
-            // I don't like the hacks required for compression but that's on vanilla, we can't fix it.
-            String decoderName = ctx.pipeline().names().contains("inbound_config") ? "inbound_config" : "decoder";
-            ctx.pipeline().addBefore(decoderName, PacketEvents.DECODER_NAME, decoder);
-            String encoderName = ctx.pipeline().names().contains("outbound_config") ? "outbound_config" : "encoder";
-            ctx.pipeline().addBefore(encoderName, PacketEvents.ENCODER_NAME, encoder);
+
+            if (force) {
+                boolean decoderGood = isAlreadyBefore(ctx, decoderName, targetDecoderName)
+                        && isAlreadyAfter(ctx, decoderName, "decompress");
+                boolean encoderGood = isAlreadyBefore(ctx, encoderName, targetEncoderName)
+                        && isAlreadyAfter(ctx, encoderName, "compress");
+
+                if (decoderGood && encoderGood) {
+                    return;
+                }
+            }
+
+            PacketEventsDecoder existingDecoder = (PacketEventsDecoder) ctx.pipeline().get(decoderName);
+            ChannelHandler encoder;
+            PacketEventsDecoder decoder;
+
+            if (existingDecoder != null) {
+                // This patches a bug where PE 2.0 handlers keep jumping behind one another causing a stackoverflow
+                if (existingDecoder.hasBeenRelocated && !force) return;
+                // Make sure we only relocate because of compression once
+                existingDecoder.hasBeenRelocated = true;
+
+                decoder = new PacketEventsDecoder((PacketEventsDecoder) ctx.pipeline().remove(decoderName));
+                encoder = new PacketEventsEncoder(ctx.pipeline().remove(encoderName));
+            } else {
+                encoder = new PacketEventsEncoder(user, preVia);
+                decoder = new PacketEventsDecoder(user, preVia);
+            }
+
+            if (preVia) {
+                ctx.pipeline()
+                        .addBefore("via-encoder", encoderName, encoder)
+                        .addBefore("via-decoder", decoderName, decoder);
+            } else {
+                // We are targeting the encoder and decoder since we don't want to target specific plugins
+                // (ProtocolSupport has changed its handler name in the past)
+                // I don't like the hacks required for compression but that's on vanilla, we can't fix it.
+                ctx.pipeline()
+                        .addBefore(targetDecoderName, decoderName, decoder)
+                        .addBefore(targetEncoderName, encoderName, encoder);
+            }
         } catch (NoSuchElementException ex) {
             String handlers = ChannelHelper.pipelineHandlerNamesAsString(ctx);
             throw new IllegalStateException("PacketEvents failed to add a decoder to the netty pipeline. Pipeline handlers: " + handlers, ex);
         }
+    }
+
+    private static boolean isAlreadyBefore(Channel ctx, String myHandler, String targetHandler) {
+        List<String> names = ctx.pipeline().names();
+        int myIndex = names.indexOf(myHandler);
+        int targetIndex = names.indexOf(targetHandler);
+
+        if (myIndex == -1) return false;
+        if (targetIndex == -1) return true;
+
+        return myIndex < targetIndex;
+    }
+
+    private static boolean isAlreadyAfter(Channel ctx, String myHandler, String targetHandler) {
+        List<String> names = ctx.pipeline().names();
+        int myIndex = names.indexOf(myHandler);
+        int targetIndex = names.indexOf(targetHandler);
+
+        if (myIndex == -1) return false;
+        if (targetIndex == -1) return true;
+
+        return myIndex > targetIndex;
     }
 }

--- a/sponge/src/main/java/io/github/retrooper/packetevents/sponge/injector/handlers/PacketEventsDecoder.java
+++ b/sponge/src/main/java/io/github/retrooper/packetevents/sponge/injector/handlers/PacketEventsDecoder.java
@@ -28,6 +28,7 @@ import com.github.retrooper.packetevents.util.PacketEventsImplHelper;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerDisconnect;
 import io.github.retrooper.packetevents.sponge.injector.connection.ServerConnectionInitializer;
 import io.github.retrooper.packetevents.sponge.util.SpongeReflectionUtil;
+import io.github.retrooper.packetevents.sponge.util.viaversion.ViaVersionUtil;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageDecoder;
@@ -44,19 +45,29 @@ public class PacketEventsDecoder extends MessageToMessageDecoder<ByteBuf> {
     public User user;
     public UUID player;
     public boolean hasBeenRelocated;
+    public boolean preViaVersion;
 
-    public PacketEventsDecoder(User user) {
+    public PacketEventsDecoder(User user, boolean preViaVersion) {
         this.user = user;
+        this.preViaVersion = preViaVersion;
     }
 
     public PacketEventsDecoder(PacketEventsDecoder decoder) {
         user = decoder.user;
         player = decoder.player;
         hasBeenRelocated = decoder.hasBeenRelocated;
+        preViaVersion = decoder.preViaVersion;
     }
 
     public void read(ChannelHandlerContext ctx, ByteBuf input, List<Object> out) throws Exception {
-        PacketEventsImplHelper.handleServerBoundPacket(ctx.channel(), user, player == null ? null : Sponge.server().player(player).orElse(null), input, true);
+        Object resolvedPlayer = player == null ? null : Sponge.server().player(player).orElse(null);
+
+        // We still call preVia listeners if ViaVersion is not available
+        if (!preViaVersion && PacketEvents.getAPI().getSettings().isPreViaInjection() && !ViaVersionUtil.isAvailable()) {
+            PacketEventsImplHelper.handleServerBoundPacket(ctx.channel(), user, resolvedPlayer, input, preViaVersion);
+        }
+
+        PacketEventsImplHelper.handleServerBoundPacket(ctx.channel(), user, resolvedPlayer, input, !preViaVersion);
         out.add(ByteBufHelper.retain(input));
     }
 
@@ -103,7 +114,11 @@ public class PacketEventsDecoder extends MessageToMessageDecoder<ByteBuf> {
     @Override
     public void userEventTriggered(final ChannelHandlerContext ctx, final Object event) throws Exception {
         // Via changes the order of handlers in this event, so we must respond to Via changing their stuff
-        ServerConnectionInitializer.relocateHandlers(ctx.channel(), this, user);
+        if (!preViaVersion) {
+            ServerConnectionInitializer.relocateHandlers(ctx.channel(), user, false, true);
+            if (PacketEvents.getAPI().getSettings().isPreViaInjection() && ViaVersionUtil.isAvailable())
+                ServerConnectionInitializer.relocateHandlers(ctx.channel(), user, true, true);
+        }
         super.userEventTriggered(ctx, event);
     }
 

--- a/sponge/src/main/java/io/github/retrooper/packetevents/sponge/injector/handlers/PacketEventsEncoder.java
+++ b/sponge/src/main/java/io/github/retrooper/packetevents/sponge/injector/handlers/PacketEventsEncoder.java
@@ -30,6 +30,7 @@ import com.github.retrooper.packetevents.util.ExceptionUtil;
 import com.github.retrooper.packetevents.util.PacketEventsImplHelper;
 import io.github.retrooper.packetevents.sponge.injector.connection.ServerConnectionInitializer;
 import io.github.retrooper.packetevents.sponge.util.viaversion.CustomPipelineUtil;
+import io.github.retrooper.packetevents.sponge.util.viaversion.ViaVersionUtil;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
@@ -49,9 +50,11 @@ public class PacketEventsEncoder extends MessageToMessageEncoder<ByteBuf> {
     public UUID player;
     private boolean handledCompression;
     private ChannelPromise promise;
+    private boolean preVia;
 
-    public PacketEventsEncoder(User user) {
+    public PacketEventsEncoder(User user, boolean preVia) {
         this.user = user;
+        this.preVia = preVia;
     }
 
     public PacketEventsEncoder(ChannelHandler encoder) {
@@ -59,12 +62,17 @@ public class PacketEventsEncoder extends MessageToMessageEncoder<ByteBuf> {
         player = ((PacketEventsEncoder) encoder).player;
         handledCompression = ((PacketEventsEncoder) encoder).handledCompression;
         promise = ((PacketEventsEncoder) encoder).promise;
+        preVia = ((PacketEventsEncoder) encoder).preVia;
     }
 
     @Override
     protected void encode(ChannelHandlerContext ctx, ByteBuf byteBuf, List<Object> list) throws Exception {
         boolean needsRecompression = !handledCompression && handleCompression(ctx, byteBuf);
-        handleClientBoundPacket(ctx.channel(), user, player, byteBuf, this.promise);
+        handleClientBoundPacket(ctx.channel(), user, player, byteBuf, this.promise, preVia);
+
+        // We still call preVia listeners if ViaVersion is not available
+        if (!preVia && PacketEvents.getAPI().getSettings().isPreViaInjection() && !ViaVersionUtil.isAvailable())
+            handleClientBoundPacket(ctx.channel(), user, player, byteBuf, this.promise, !preVia);
 
         if (needsRecompression) {
             compress(ctx, byteBuf);
@@ -78,8 +86,9 @@ public class PacketEventsEncoder extends MessageToMessageEncoder<ByteBuf> {
         list.add(byteBuf.retain());
     }
 
-    private @Nullable PacketSendEvent handleClientBoundPacket(Channel channel, User user, UUID player, ByteBuf buffer, ChannelPromise promise) throws Exception {
-        PacketSendEvent packetSendEvent = PacketEventsImplHelper.handleClientBoundPacket(channel, user, player == null ? null : Sponge.server().player(player).orElse(null), buffer, true);
+    private @Nullable PacketSendEvent handleClientBoundPacket(Channel channel, User user, UUID player, ByteBuf buffer, ChannelPromise promise, boolean preVia) throws Exception {
+        Object resolvedPlayer = player == null ? null : Sponge.server().player(player).orElse(null);
+        PacketSendEvent packetSendEvent = PacketEventsImplHelper.handleClientBoundPacket(channel, user, resolvedPlayer, buffer, !preVia);
         if (packetSendEvent != null && packetSendEvent.hasTasksAfterSend()) {
             promise.addListener((p) -> {
                 for (Runnable task : packetSendEvent.getTasksAfterSend()) {
@@ -157,15 +166,14 @@ public class PacketEventsEncoder extends MessageToMessageEncoder<ByteBuf> {
         int compressIndex = ctx.pipeline().names().indexOf("compress");
         if (compressIndex == -1) return false;
         handledCompression = true;
-        int peEncoderIndex = ctx.pipeline().names().indexOf(PacketEvents.ENCODER_NAME);
+        int peEncoderIndex = ctx.pipeline().names().indexOf((preVia ? "pre-" : "") + PacketEvents.ENCODER_NAME);
         if (peEncoderIndex == -1) return false;
         if (compressIndex > peEncoderIndex) {
             //We are ahead of the decompression handler (they are added dynamically) so let us relocate.
             //But first we need to compress the data and re-compress it after we do all our processing to avoid issues.
             decompress(ctx, buffer, buffer);
             //Let us relocate and no longer deal with compression.
-            PacketEventsDecoder decoder = (PacketEventsDecoder) ctx.pipeline().get(PacketEvents.DECODER_NAME);
-            ServerConnectionInitializer.relocateHandlers(ctx.channel(), decoder, user);
+            ServerConnectionInitializer.relocateHandlers(ctx.channel(), user, preVia, false);
             return true;
         }
         return false;


### PR DESCRIPTION
The Sponge module's injector was ported before pre-via support landed, so PacketEventsImplHelper was always called with autoProtocolTranslation hardcoded to true and the EventManager only ever fired listeners with isPreVia()==false. Pre-via listeners (e.g. Grim's PacketPlayerTick, PacketPlayerSteer, PacketEntityAction) never received any packets, regardless of whether ViaVersion was installed.

Mirrors the Spigot implementation:
- ServerConnectionInitializer.relocateHandlers gains a preVia parameter and inserts a second pe-encoder/pe-decoder pair before via-encoder/ via-decoder when ViaVersion is available.
- When ViaVersion is absent, the normal handler also fires the pre-via listener set so behavior is consistent across configurations.
- PacketEventsDecoder/Encoder track the preVia flag, propagate it through copy constructors, and userEventTriggered/handleCompression re-relocate the correct pipeline slot.